### PR TITLE
Don't die if Rack::Lint is loaded

### DIFF
--- a/lib/rack/exception_notifier.rb
+++ b/lib/rack/exception_notifier.rb
@@ -40,7 +40,7 @@ module Rack
     end
 
     def _body_present?(env)
-      env['rack.input'].size > 0
+      env['rack.input'].read(1)
     end
 
     def _exclude_env_key?(env, key)


### PR DESCRIPTION
Rack::Lint is loaded by default in development, and changes the type of
`env['rack.input']` to a Rack::Lint::InputWrapper, which does not respond to
`size`.

Fix copied from:
https://github.com/joshfrench/rack-timeout/commit/06af2cb7f767b94c9c9e777707cdcbf760e8811f
